### PR TITLE
runt-of-the-web.com, accountkiller.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -213,6 +213,14 @@ techcrunch.com##.sidebar--main
 imore.com##div.sidebar__section
 imore.com##.sidebar
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/7
+runt-of-the-web.com##.leaderboard
+runt-of-the-web.com##.pbh_inline
+runt-of-the-web.com##.mrec
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/7
+accountkiller.com##.section_box[style="background-color: rgb(102, 181, 255);"]
+
 # -------------------------------------------------------------------------------------------------------------------- #
 
 # English NSFW


### PR DESCRIPTION
A pretty small pull this time around. By now I've exhausted most of my sources for sites that have empty placeholders.

Example pages:

```
! https://runt-of-the-web.com/worst-youtube-comments
runt-of-the-web.com##.leaderboard
runt-of-the-web.com##.pbh_inline
! https://runt-of-the-web.com/spotify-marketing
runt-of-the-web.com##.mrec
! https://www.accountkiller.com/en/delete-htcdev-account
accountkiller.com##.section_box[style="background-color: rgb(102, 181, 255);"]
```