### PR TITLE
sourceforge.net, borncity.com, pixiv.net

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -249,6 +249,16 @@ reality.news##.whtaph-floatbox
 alcpu.com###topbarad
 alcpu.com###navlinkad
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/9
+sourceforge.net##.main-content > section.sterling
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/9
+borncity.com##.code-block
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/9
+pixiv.net##.sc-gMcBNU
+pixiv.net##div:nth-of-type(2) > ._3jgsYyw
+
 # -------------------------------------------------------------------------------------------------------------------- #
 
 # English NSFW

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -10,8 +10,11 @@
 # Multilingual
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/1#issuecomment-450592268
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/9
 pixiv.net##._2vNejsc
 pixiv.net##.ads-top-info
+pixiv.net##.sc-gMcBNU
+pixiv.net##div:nth-of-type(2) > ._3jgsYyw
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/3#issuecomment-450736303
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/5#issuecomment-452149638
@@ -254,10 +257,6 @@ sourceforge.net##.main-content > section.sterling
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/9
 borncity.com##.code-block
-
-# https://github.com/NanoAdblockerLab/NanoContrib/pull/9
-pixiv.net##.sc-gMcBNU
-pixiv.net##div:nth-of-type(2) > ._3jgsYyw
 
 # -------------------------------------------------------------------------------------------------------------------- #
 


### PR DESCRIPTION
I must admit that when I first stumbled across this list in Nano Adblocker's list set, I thought that more people would've been enthusiastic about this list than what has been the case so far, seeing as I'm the only one who've made pull requests for it so far.

Example pages:

```
! https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.1.5/qbittorrent_4.1.5_x64_setup.exe/download (Will attempt to initiate a download of qBittorrent when the page is opened)
sourceforge.net##.main-content > section.sterling
! https://borncity.com/win/2019/01/17/windows-10-v1809-announced-as-general-available/
borncity.com##.code-block
! https://www.pixiv.net/member_illust.php?mode=manga&illust_id=62337642 (Requires being logged on to see the effects of)
pixiv.net##.sc-gMcBNU
pixiv.net##div:nth-of-type(2) > ._3jgsYyw
```