### PR TITLE
filehorse.com, simkl.com, color-hex.com, guidatv.quotidiano.net

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -33,6 +33,9 @@ pokemonpets.com##.NiceBg[style^="width: 120px; "]
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/11#issuecomment-463024370
 mightytext.net###ad-block-holder
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/13
+filehorse.com##div[class^="dx-pr-"]
+
 # -------------------------------------------------------------------------------------------------------------------- #
 
 # Dhivehi
@@ -295,6 +298,12 @@ flipside.keenspot.com###flip_dafoot
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/12#issuecomment-468103880
 fallouttoyworks.keenspot.com##div[class="shadow"]:has(div[id^="div-gpt-ad-"])
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/13
+simkl.com##.blockplacecenter
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/13
+color-hex.com##hr
+
 # -------------------------------------------------------------------------------------------------------------------- #
 
 # English NSFW
@@ -312,6 +321,9 @@ motherless.com##.text-right.col-lg-4.col-xs-12.col-sm-12.view-right > div:nth-of
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/5#issuecomment-452149803
 excite.it##.cLeft.alpha.g_3
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/13
+guidatv.quotidiano.net###Leader
 
 # -------------------------------------------------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Same procedure as usual.

Example pages:

```
! https://guidatv.quotidiano.net/k2/
guidatv.quotidiano.net###Leader
! https://simkl.com/tv/49368/zack-and-quack/season-2/episode-19/
simkl.com##.blockplacecenter
! https://www.color-hex.com/
color-hex.com##hr
! https://www.filehorse.com/download-google-chrome-64/
filehorse.com##div[class^="dx-pr-"]
```

PS: You may or may not have been wondering why I haven't submitted any Nordic entries to this list, despite me being from that area? That is because my Nordic list aims to take care of empty boxes, as one of very few ad-removing lists to do so. So if you ever do get any requests about empty boxes on Norwegian or Danish websites, you are welcome to give me a FYI about it, if you want to.