### PR TITLE
echoroukonline.com, prothomalo.com, ahram.org.eg

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -60,7 +60,23 @@ techadvisor.*###bottomLeaderBoardHolder
 whatmobile.com.pk##div[style^="background-color"]:has(script[src*="adsbygoogle.js"])
 whatmobile.com.pk##div[style^="height:610px"]
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/19
+echoroukonline.com##.ads-unit
+echoroukonline.com##.t3c__grid > div:has(.side-ads)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/19
+prothomalo.com##.common_google_ads
+
 # End Multilingual
+
+# -------------------------------------------------------------------------------------------------------------------- #
+
+# Arabic
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/19
+ahram.org.eg###AdsFloating_divFloating
+
+# End Arabic
 
 # -------------------------------------------------------------------------------------------------------------------- #
 


### PR DESCRIPTION
While doing research for a completely different list, I found some entries for Arabic sites.

Example pages:

```
! https://www.echoroukonline.com/
echoroukonline.com##.ads-unit
echoroukonline.com##.t3c__grid > div:has(.side-ads)
! https://www.prothomalo.com/
prothomalo.com##.common_google_ads
! http://www.ahram.org.eg
ahram.org.eg###AdsFloating_divFloating
```