### PR TITLE
reddit.com, opencritic.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -21,8 +21,10 @@ pixiv.net##.ad-frame-container
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/3#issuecomment-450736303
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/5#issuecomment-452149638
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/21
 reddit.com##div.fePAzF:has(div[id^="sidebar-"])
 reddit.com###overlay-comment-atf
+reddit.com###comment-atf
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/10#issuecomment-459593858
 quizlet.com##.ModeLayout-ad
@@ -393,6 +395,9 @@ usgamer.net##.leaderboard-container
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/20#issuecomment-485269960
 manualslib.com##.manualban-bot
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/21
+opencritic.com##.review-row:has(app-advertisement)
 
 # End English
 


### PR DESCRIPTION
A pretty small submission this time.

Example pages:

```
! https://www.reddit.com/r/insanepeoplefacebook/comments/bfnoli/yeah_i_remember_jesus_bragging_about_americas/ (New Reddit mode)
reddit.com###comment-atf
! https://opencritic.com/game/6864/PAW-Patrol:-On-a-Roll/reviews
opencritic.com##.review-row:has(app-advertisement)
```

Note that `reddit.com###comment-atf` and the previously added `reddit.com###overlay-comment-atf` seem to be used more or less interchangeably by Reddit; so if you were to not see any immediately obvious use of the former upon testing it, you'd have to take my word for it.