### PR TITLE
reverso.net, thehardtimes.net, rule34.paheal.net

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -471,7 +471,7 @@ motherless.com###main > .text-center:has(div[id^="ad-footer-"])
 motherless.com##.text-right.col-lg-4.col-xs-12.col-sm-12.view-right > div:nth-of-type(1)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/25
-rule34.paheal.net##.blockbody:has(:scope > span > a[href$="/bad_ads"])
+rule34.paheal.net##section:has(:scope > .blockbody > span > a[href$="/bad_ads"])
 rule34.paheal.net##a:has(:scope > img[src*="/ads/"])
 rule34.paheal.net##.blockbody:has(a[href$="/bad_ads"]) > br
 rule34.paheal.net##.blockbody > [href="https://rule34.paheal.net/wiki/bad_ads"]

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -472,7 +472,6 @@ motherless.com##.text-right.col-lg-4.col-xs-12.col-sm-12.view-right > div:nth-of
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/25
 rule34.paheal.net##section:has(:scope > .blockbody > span > a[href$="/bad_ads"])
-rule34.paheal.net##a:has(:scope > img[src*="/ads/"])
 rule34.paheal.net##.blockbody:has(a[href$="/bad_ads"]) > br
 rule34.paheal.net##.blockbody > [href="https://rule34.paheal.net/wiki/bad_ads"]
 rule34.paheal.net##section:has(:scope > .blockbody > div[align="center"])

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -82,6 +82,9 @@ reuters.com##.RightRail_sticky:has(.DPSlot_slot)
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/24#issuecomment-494611995
 fonts2u.com###banner_bottom
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/25
+grammaire.reverso.net,grammar.reverso.net###ads
+
 # End Multilingual
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -450,6 +453,9 @@ webfonts0.com##div:has(:scope > .adsbygoogle)
 
 # https://github.com/NanoMeow/QuickReports/issues/1043
 bleepingcomputer.com##.cz-related-article-wrapp:has(:scope > .adsbygoogle)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/25
+thehardtimes.net##.code-block:has(script:has-text(googletag))
 
 # End English
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -472,7 +472,7 @@ motherless.com##.text-right.col-lg-4.col-xs-12.col-sm-12.view-right > div:nth-of
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/25
 rule34.paheal.net##.blockbody:has(:scope > span > a[href$="/bad_ads"])
-rule34.paheal.net##a:has(:scope > img[alt="HentaiKey"])
+rule34.paheal.net##a:has(:scope > img[src*="/ads/"])
 rule34.paheal.net##.blockbody:has(a[href$="/bad_ads"]) > br
 rule34.paheal.net##.blockbody > [href="https://rule34.paheal.net/wiki/bad_ads"]
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -475,6 +475,7 @@ rule34.paheal.net##section:has(:scope > .blockbody > span > a[href$="/bad_ads"])
 rule34.paheal.net##a:has(:scope > img[src*="/ads/"])
 rule34.paheal.net##.blockbody:has(a[href$="/bad_ads"]) > br
 rule34.paheal.net##.blockbody > [href="https://rule34.paheal.net/wiki/bad_ads"]
+rule34.paheal.net##section:has(:scope > .blockbody > div[align="center"])
 
 # End English NSFW
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -470,6 +470,12 @@ yespornplease.com##.well:has(:scope > center > iframe[src^="https://a.adtng.com/
 motherless.com###main > .text-center:has(div[id^="ad-footer-"])
 motherless.com##.text-right.col-lg-4.col-xs-12.col-sm-12.view-right > div:nth-of-type(1)
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/25
+rule34.paheal.net##.blockbody:has(:scope > span > a[href$="/bad_ads"])
+rule34.paheal.net##a:has(:scope > img[alt="HentaiKey"])
+rule34.paheal.net##.blockbody:has(a[href$="/bad_ads"]) > br
+rule34.paheal.net##.blockbody > [href="https://rule34.paheal.net/wiki/bad_ads"]
+
 # End English NSFW
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
You may have noticed by now that I always have at least 2 entries in my pull requests. That way I won't feel like I'd have to make PRs four times a week, but can also make singular entries stay in my backlog for up to 2 weeks at a time.

Example pages:
```
! https://thehardtimes.net/hardstyle/didnt-vaccinate-kids-one-lived-turned-fine/
thehardtimes.net##.code-block:has(script:has-text(googletag))
! http://grammaire.reverso.net/
! http://grammar.reverso.net/
grammaire.reverso.net,grammar.reverso.net###ads
! https://rule34.paheal.net/post/view/12639 (NSFW, which shouldn't come as a surprise.)
rule34.paheal.net##section:has(:scope > .blockbody > span > a[href$="/bad_ads"])
rule34.paheal.net##.blockbody:has(a[href$="/bad_ads"]) > br
rule34.paheal.net##.blockbody > [href="https://rule34.paheal.net/wiki/bad_ads"]
rule34.paheal.net##section:has(:scope > .blockbody > div[align="center"])
```