### PR TITLE
mediabiasfactcheck.com, rugbyworld.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -687,6 +687,12 @@ globalnews.ca##.stream-ad-read-more
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/44#issuecomment-519327934
 techjunkie.com##.qualcont
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/45
+mediabiasfactcheck.com##center:has(script[src*="/adsbygoogle."])
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/45
+rugbyworld.com##.apester-element
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
Example pages:

```
! https://mediabiasfactcheck.com/christian-action-network/
mediabiasfactcheck.com##center:has(script[src*="/adsbygoogle."])
! https://www.rugbyworld.com/tournaments/rugby-world-cup-2019/rugby-world-cup-tv-coverage-94637 (Requires either signing up to their newsletter or using https://raw.githubusercontent.com/DandelionSprout/adfilt/master/BrowseWebsitesWithoutLoggingIn.txt, in order to see enough of the article to see the placeholder.)
rugbyworld.com##.apester-element
```