### PR TITLE
telegraph.co.uk, blog.goo.ne.jp

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -693,6 +693,9 @@ mediabiasfactcheck.com##center:has(script[src*="/adsbygoogle."])
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/45#issuecomment-520242717
 rugbyworld.com##.apester-element
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/46
+telegraph.co.uk##div[class*="picGrid-"]:has(a[href^="/sponsored/"])
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -785,6 +788,10 @@ poipiku.com##.PcSideBarAd
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/34#issuecomment-508301016
 min.dododori.com###fix-space
 min.dododori.com##footer:style(padding-bottom: 10px !important)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/46
+blog.goo.ne.jp##.content-top
+blog.goo.ne.jp##.content-bottom
 
 # End Japanese
 


### PR DESCRIPTION
Example pages:

```
! https://www.telegraph.co.uk/news/uknews/crime/10345050/Supermarket-thiefs-loose-onion-scam-ends-in-tears.html
telegraph.co.uk##div[class*="picGrid-"]:has(a[href^="/sponsored/"])
! https://blog.goo.ne.jp/suzuran2012/m/201811
blog.goo.ne.jp##.content-top
blog.goo.ne.jp##.content-bottom
```