### PR TITLE
toranoana.jp, pinknews.co.uk

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -712,6 +712,9 @@ thesilphroad.com###keepinTheLightsOnWrap:style(height: 1px !important;)
 thesilphroad.com##p:has-text(Why Ads?)
 thesilphroad.com##div.light:has(:scope span.ezoic-ad)
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/48
+pinknews.co.uk##div[class^="pn-ad-"]
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -830,6 +833,9 @@ momoniji.com##.widget-content-top:has(script[src*="://blogroll.livedoor.net/js/b
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/34#issuecomment-508301035
 seiga.nicovideo.jp###top_ads_box
 seiga.nicovideo.jp##.ads_prtext
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/48
+toranoana.jp##.tora-ads-list-item
 
 # End Japanese NSFW
 


### PR DESCRIPTION
Note that while `Toranoana` has a language selector, all non-Japanese options seem to simply lead to an info page about the company.

Example pages:

```
! https://www.toranoana.jp/
toranoana.jp##.tora-ads-list-item
! https://www.pinknews.co.uk/2019/08/22/us-christian-homophobic-transphobic-leaflets-uk-homes-birmingham-tradition-family-property/
pinknews.co.uk##div[class^="pn-ad-"]
```