### PR TITLE
thejc.com, crash.net

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -830,6 +830,12 @@ accuweather.com##.ad
 forbes.com##medianet
 forbes.com##.vestpocket
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/56
+thejc.com##.grid__item:has(:scope > .advert):not(:has(a))
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/56
+crash.net##.sidebar-ad-area
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -165,15 +165,6 @@ filgoal.com##div.nth1:has(:scope > #POSTQUARE_WIDGET_ASIDE)
 
 # -------------------------------------------------------------------------------------------------------------------- #
 
-# Bosnians
-
-# https://github.com/NanoMeow/QuickReports/issues/1916
-forum.benchmark.rs##div:has(:scope > [id^="div-gpt-ad-"])
-
-# End Bosnians
-
-# -------------------------------------------------------------------------------------------------------------------- #
-
 # Chinese (Simplified)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/16#issuecomment-473483183
@@ -1032,6 +1023,15 @@ dn.pt##.t-pub-inner
 vejasp.abril.com.br##[id^="superbanner"]:has(.ad-top)
 
 # End Portuguese
+
+# -------------------------------------------------------------------------------------------------------------------- #
+
+# Serbo-Croatian
+
+# https://github.com/NanoMeow/QuickReports/issues/1916
+forum.benchmark.rs##div:has(:scope > [id^="div-gpt-ad-"])
+
+# End Serbo-Croatian
 
 # -------------------------------------------------------------------------------------------------------------------- #
 


### PR DESCRIPTION
I also chose to change the name of the *Bosnians* category to *Serbo-Croatian*, as that term covers the almost identical languages known to locals there as "Serbian", "Bosnian", "Montenegrin", or "Croatian", be it in Latin or Cyrillic script.

Example pages:

```
! https://www.thejc.com/
thejc.com##.grid__item:has(:scope > .advert):not(:has(a))
! https://www.crash.net/motogp/news/218064/1/finlands-kymi-ring-to-bid-for-motogp-shun-f1
crash.net##.sidebar-ad-area
```