### PR TITLE
theage.com.au, digminecraft.com, gamersnexus.net

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -918,7 +918,7 @@ theage.com.au##div[id^="adspot"]
 digminecraft.com##.slot
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/63
-gamersnexus.net##.moduleContent:has-text(/^\n			Advertisements:\n/)
+gamersnexus.net##.moduleContent:has-text(/^\n\t\t\tAdvertisements:\n/)
 
 # End English
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -911,6 +911,15 @@ gamefaqs.gamespot.com###leader_top
 nulledpremium.com##.sidebar-widget:has(:scope > div > .adsbygoogle)
 nulledpremium.com##.code-block:has(:scope > .adsbygoogle)
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/63
+theage.com.au##div[id^="adspot"]
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/63
+digminecraft.com##.slot
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/63
+gamersnexus.net##.moduleContent:has-text(/^\n			Advertisements:\n/)
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
Example sites:

```
! https://www.theage.com.au/
theage.com.au##div[id^="adspot"]
! https://www.digminecraft.com/game_commands/connect_command.php
digminecraft.com##.slot
! https://www.gamersnexus.net/guides/3494-amd-ryzen-3000-undervolting-offset-override
gamersnexus.net##.moduleContent:has-text(/^\n\t\t\tAdvertisements:\n/)
```