### PR TITLE
universitystar.com, happymag.tv, reason.com, bigthink.com, realclearpolicy.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1058,6 +1058,9 @@ reason.com##.magicSidebar
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/71
 bigthink.com##.rebellt-item:not(:has(a))
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/71
+realclearpolicy.com##div[style*="float: left; width: 300px;"]
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1046,6 +1046,18 @@ animesuperhero.com##.secondaryContent
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/70#issuecomment-567284298
 smalljoys.tv##.sm_dfp_ads
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/71
+universitystar.com###leaderboard
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/71
+happymag.tv##.g
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/71
+reason.com##.magicSidebar
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/71
+bigthink.com##.rebellt-item:not(:has(a))
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
If I've calculated correctly, this pull request should give this list more entries than [AdGuard's own box removal list](https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/remains.txt)!... which I only learned about the existence of three weeks ago (as it was hid deep inside their annoyances list). 😅

Example pages:

```
! https://universitystar.com/33233/opinions/cancel-culture-is-toxic/
universitystar.com###leaderboard
! https://happymag.tv/cancel-culture-wins-macquarie-dictionarys-2019-word-of-the-year/
happymag.tv##.g
! https://reason.com/2019/11/11/donald-trump-jr-ucla-book-student-silence/
reason.com##.magicSidebar
! https://bigthink.com/surprising-science/golden-blood
bigthink.com##.rebellt-item:not(:has(a))
! https://www.realclearpolicy.com/2019/10/02/the_atavism_of_cancel_culture_42991.html
realclearpolicy.com##div[style*="float: left; width: 300px;"]
```