### PR TITLE
pixiv.net, armenianweekly.com, gayemagazine.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -14,10 +14,16 @@
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/12#issuecomment-468103768
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/16#issuecomment-473483145
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/47#issuecomment-523706934
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/73
+!#if !env_mobile
 pixiv.net##.ads-top-info
 pixiv.net##.area_new:not(:has(.area_title))
+pixiv.net###root > header + div + div:not(:has(a)):not(:has(img))
+pixiv.net##.sc-AykKF:style(padding-bottom: 0px !important)
+!#endif
 !#if env_mobile
 pixiv.net##.ad-frame-container
+pixiv.net##body[style^=margin-bottom]:style(margin-bottom: 0px !important)
 !#endif
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/3#issuecomment-450736303
@@ -166,6 +172,9 @@ amazon.*##[data-ad-details]
 
 # https://github.com/NanoMeow/QuickReports/issues/2560
 ign.com##.secondary-ad
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/73
+armenianweekly.com##.mh-header-widget-1
 
 # End Multilingual
 
@@ -1075,6 +1084,11 @@ files.minecraftforge.net##.promo-container
 
 # https://github.com/NanoMeow/QuickReports/issues/2541
 zdnet.com###main > div:has(.ad-leader-plus-top)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/73
+gayemagazine.com##div[style*="width:320px;height:"]
+gayemagazine.com##div[style^="width: 320px; height:"]
+wix.com##iframe[src*="static.parastorage.com/unpkg/"]
 
 # End English
 


### PR DESCRIPTION
Notes:
* I've become aware that Pixiv entries can be pretty resource-consuming, especially on phones, so I've begun to feel that it's time to limit them to platforms to a much stronger degree. Sure it may be a big factor that I also use (and maintain) ~8 other lists that remove Pixiv images that use any one of ~400 different terms or RegEx-terms, but still.
* The use of `wix.com` is intentional, as the `iframe` in question seems to be loaded from the blog's underlying blog engine website as a third-party element.

Example pages:

```
! https://www.pixiv.net/en/tags/princess_dress/artworks
pixiv.net###root > header + div + div:not(:has(a)):not(:has(img))
! https://www.pixiv.net/en/artworks/74743932
pixiv.net##.sc-AykKF:style(padding-bottom: 0px !important)
! https://www.pixiv.net/en/tags/princess_dress/illustrations (Phone user agent only)
pixiv.net##body[style^=margin-bottom]:style(margin-bottom: 0px !important)
! https://armenianweekly.com/
armenianweekly.com##.mh-header-widget-1
! https://www.gayemagazine.com/post/photographer-launches-boys-can-be-princesses-too-campaign-social-media-reacts
gayemagazine.com##div[style*="width:320px;height:"]
gayemagazine.com##div[style^="width: 320px; height:"]
wix.com##iframe[src*="static.parastorage.com/unpkg/"]
```