### PR TITLE
nytimes.com, askapache.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1143,6 +1143,12 @@ ratemyprofessors.com##[class^="StickyLeaderboard__"]
 ratemyprofessors.com##[class^="AdRail__"]
 ratemyprofessors.com##[class*="__AdWrapper-"]
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/76
+nytimes.com,nytimes3xbfgragh.onion##section[name=articleBody] > div:not(.StoryBodyCompanionColumn):not([data-testid]):not(:last-of-type)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/76
+askapache.com##.GAD
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -179,6 +179,9 @@ ign.com##.secondary-ad
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/73#issuecomment-569457513
 armenianweekly.com##.mh-header-widget-1
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/76
+nytimes.com,nytimes3xbfgragh.onion##section[name=articleBody] > div:not(.StoryBodyCompanionColumn):not([data-testid]):not(:last-of-type)
+
 # End Multilingual
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -1142,9 +1145,6 @@ ratemyprofessors.com##+js(remove-attr, class, #body)
 ratemyprofessors.com##[class^="StickyLeaderboard__"]
 ratemyprofessors.com##[class^="AdRail__"]
 ratemyprofessors.com##[class*="__AdWrapper-"]
-
-# https://github.com/NanoAdblockerLab/NanoContrib/pull/76
-nytimes.com,nytimes3xbfgragh.onion##section[name=articleBody] > div:not(.StoryBodyCompanionColumn):not([data-testid]):not(:last-of-type)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/76
 askapache.com##.GAD


### PR DESCRIPTION
A pretty simple pull this time around.

```
! https://www.nytimes.com/2019/12/23/us/matt-shea-washington-extremism.html
nytimes.com,nytimes3xbfgragh.onion##section[name=articleBody] > div:not(.StoryBodyCompanionColumn):not([data-testid]):not(:last-of-type)
! https://www.askapache.com/online-tools/htpasswd-generator/
askapache.com##.GAD
```