### PR TITLE
douglascountrysentinel.com, hpenews.com, xda-developers.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1323,6 +1323,12 @@ retaildive.com##.show-large:has(#dfp-leaderboard-desktop)
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/91#issuecomment-587091119
 tellerreport.com##.ads
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/92
+douglascountysentinel.com,hpenews.com##.dfpAd
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/92
+forum.xda-developers.com##.leaderboard
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
I suspect there may very well be several more local US newspapers that use the same GUI backend and who'd also need `##.dfpAd` entries, but it'd take me some more days to find them.

Example pages:

```
! https://douglascountysentinel.com/
! https://hpenews.com/
douglascountysentinel.com,hpenews.com##.dfpAd

! https://forum.xda-developers.com/apps/magisk
forum.xda-developers.com##.leaderboard
```