### PR TITLE
boston.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1102,7 +1102,7 @@ amny.com##.gridlove-sidebar
 amny.com##.gridlove-posts.row > div:has(.gridlove-inject)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/67#issuecomment-562770868
-boston.com##.site-container:style(margin-top: -100px !important;)
+boston.com##body:style(padding-top: 110px !important;)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/67#issuecomment-562770885
 bustle.com##.ka.gr.gq


### PR DESCRIPTION
Better mirror intended site design for boston.com (check via web inspector) so site doesn't break unexpectedly with other filter lists loaded (e.g. Web Annoyances Ultralist)

With webannoyances ultralist, Page title heading is no longer hidden on example link with updated filter: `https://www.boston.com/news/health/2020/03/01/coronavirus-may-have-spread-undetected-for-weeks-in-u-s`

Related: NanoAdblockerLab#67 (comment)