### PR TITLE
indiatoday.in, dailystar.co.uk

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1701,6 +1701,13 @@ peazip.org##td:has(:scope > .adsbygoogle)
 howtoforge.com##div[style="height:100px;"]
 howtoforge.com###htfContentList li:has(:scope > div[style="padding-left:35%;"])
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/111
+indiatoday.in##.inline-story-add
+indiatoday.in##.story-header-ad
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/111
+dailystar.co.uk##body:style(margin-top: 0px !important)
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
Example pages:
```
! https://www.indiatoday.in/world/story/china-pressured-eu-drop-covid-disinformation-criticism-sources-1671054-2020-04-25
indiatoday.in##.inline-story-add
indiatoday.in##.story-header-ad
! https://www.dailystar.co.uk/
dailystar.co.uk##body:style(margin-top: 0px !important)
```