### PR TITLE
variety.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1817,7 +1817,7 @@ digitaltrends.com##.b-placard
 # https://github.com/NanoMeow/QuickReports/issues/2507
 wsj.com##.snippet-right-ad
 
-
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/117
 variety.com###leaderboard-no-padding
 
 # End English

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1817,6 +1817,9 @@ digitaltrends.com##.b-placard
 # https://github.com/NanoMeow/QuickReports/issues/2507
 wsj.com##.snippet-right-ad
 
+
+variety.com###leaderboard-no-padding
+
 # End English
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
Empty leaderboard ad box at top of page on test link `https://variety.com/2020/tv/news/andrew-ross-sorkin-joe-kernan-cnbc-coronavirus-deaths-1234617140/`