### PR TITLE
16 domains

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1873,7 +1873,11 @@ apnews.com##.bellow-article
 apnews.com##div[class^="Component-dfp-"]
 
 # https://github.com/NanoMeow/QuickReports/issues/4042
-games.dailymail.co.uk##div[data-element-description$=" ad"]
+! Arkadium games new design
+games.baltimoresun.com,games.charlotteobserver.com,games.chicagotribune.com,games.dailypress.com,games.mcall.com,games.nydailynews.com,games.orlandosentinel.com,arkadiumarena.com,games.sun-sentinel.com,games.dailymail.co.uk##div[data-element-description$=" ad"]
+! Arkadium games old design
+games.express.co.uk,puzzles.bestforpuzzles.com,puzzles.independent.co.uk,puzzles.standard.co.uk,games.mirror.co.uk,games.usatoday.com##[display-ad-location] > *
+games.express.co.uk,puzzles.bestforpuzzles.com,puzzles.independent.co.uk,puzzles.standard.co.uk,games.mirror.co.uk,games.usatoday.com##.arena-ad-col + ark-article:style(margin-right:0!important;max-width:initial!important)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/119#issuecomment-641650527
 theguardian.com##.aside-slot-container


### PR DESCRIPTION
Sites with new design:
```
games.baltimoresun.com 
games.charlotteobserver.com
games.chicagotribune.com
games.dailypress.com
games.mcall.com
games.nydailynews.com
games.orlandosentinel.com
parade.arkadiumarena.com
games.sun-sentinel.com
games.dailymail.co.uk
parade.arkadiumarena.com
```

Sites with old design:
```
games.express.co.uk
puzzles.bestforpuzzles.com
puzzles.independent.co.uk
puzzles.standard.co.uk
games.mirror.co.uk
games.usatoday.com
```