### PR TITLE
pixiv.net, invenglobal.com, opportunitydesk.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -255,6 +255,7 @@ twitter.com##div[aria-label*=" - "] > div[style^="padding-"] > div[style^="paddi
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/77#issuecomment-574410073
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/87#issuecomment-582155483
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/112#issuecomment-626087012
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/128
 !#if !env_mobile
 pixiv.net###js-mount-point-header.with-ad:style(min-height: 0px !important;)
 pixiv.net###root > header + div + div:not(:has(a)):not(:has(img))
@@ -268,6 +269,7 @@ pixiv.net##iframe[height="60"]:upward(1)
 pixiv.net##iframe[height="90"]:upward(1)
 pixiv.net##li:has(:scope > iframe[name="infeed"])
 pixiv.net##li[size="2"][offset="1"]
+pixiv.net##.area_new:has(:scope > .area_title + div > #ads-illust_manage_rectangle)
 !#endif
 !#if env_mobile
 pixiv.net##.ad-frame-container
@@ -2041,6 +2043,14 @@ avclub.com##a[data-ga^="\[\[\"Commerce Inset"]:upward(2)
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/126#issuecomment-653651425
 bleedingcool.com##.responsive-leaderboard
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/128
+invenglobal.com##.article-ad-top
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/128
+opportunitydesk.org##.sidebar-widget:has(a[href*="bit.ly"])
+opportunitydesk.org##.sidebar-widget:has(.adsbygoogle)
+opportunitydesk.org##.textwidget:has(.adsbygoogle)
 
 # End English
 


### PR DESCRIPTION
• Fix https://github.com/NanoMeow/QuickReports/issues/4269

By now I should probably have considered rewriting the Pixiv entries entirely, but that'd be *a lot* of work for me to do.

Example pages:
```
! https://www.pixiv.net/manage/illusts/ (Requires being logged in)
pixiv.net##.area_new:has(:scope > .area_title + div > #ads-illust_manage_rectangle)

! https://www.invenglobal.com/articles/11589/sky-williams-addresses-sexual-assault-allegations-connected-to-the-sky-house
invenglobal.com##.article-ad-top

! https://opportunitydesk.org/
! https://github.com/NanoMeow/QuickReports/issues/4269
opportunitydesk.org##.sidebar-widget:has(a[href*="bit.ly"])
opportunitydesk.org##.sidebar-widget:has(.adsbygoogle)
opportunitydesk.org##.textwidget:has(.adsbygoogle)
```