### PR TITLE
independent.co.uk, dexerto.com, nkmk.me

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -1865,8 +1865,10 @@ wsj.com##.snippet-right-ad
 variety.com###leaderboard-no-padding
 
 # https://github.com/NanoMeow/QuickReports/issues/3952
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/129
 independent.co.uk##.taboola
 independent.co.uk##.under-article-prompt-donations
+independent.co.uk##.dmpu
 
 # https://github.com/NanoMeow/QuickReports/issues/3963
 moving2canada.com##.ajax_advert:upward(.sidebar_module)
@@ -2060,6 +2062,15 @@ mtlblog.com##.ad
 
 # https://github.com/NanoMeow/QuickReports/issues/4247
 anywho.com##.c-paid-ad:upward(1)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/129
+dexerto.com##.text-gray-700.text-center
+dexerto.com##.desktop-skin-container > .w-100
+dexerto.com##div[id^="topLeaderboardContainer"]
+
+# https://github.com/NanoMeow/QuickReports/issues/4285
+note.nkmk.me##.ad-block-inside
+note.nkmk.me##.side-ad-block:upward(1)
 
 # End English
 


### PR DESCRIPTION
* Fix https://github.com/NanoMeow/QuickReports/issues/4285

Example pages:
```
! https://www.independent.co.uk/
independent.co.uk##.dmpu

! https://www.dexerto.com/
dexerto.com##.text-gray-700.text-center
! https://www.dexerto.com/entertainment/danny-duncan-destroys-house-with-indoor-baseball-pitching-machine-1390345
dexerto.com##.desktop-skin-container > .w-100
dexerto.com##div[id^="topLeaderboardContainer"]

! https://github.com/NanoMeow/QuickReports/issues/4285
! https://note.nkmk.me/en/python-list-sort-sorted/
note.nkmk.me##.ad-block-inside
note.nkmk.me##.side-ad-block:upward(1)
```