### PR TITLE
8 domains

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -298,6 +298,13 @@ lmtonline.com##.ctpl-fullbanner
 marketscreener.com##.myFooter
 marketscreener.com##[id^="zpp"]
 
+# https://github.com/NanoMeow/QuickReports/issues/4266
+||engine.fxempire.com^
+||cdn.fxempire.com^
+fxempire.com##[class*="ColSystem"]>[class*="-sc-"]:has-text(/Sponsored|Advertisement/)
+fxempire.com##[class^="fx-grid__Content"]:has-text(/Advertisement/)
+fxempire.com##[class*="TopButtonAd"]
+
 # End Multilingual
 
 # -------------------------------------------------------------------------------------------------------------------- #

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -2259,7 +2259,6 @@ simpleflying.com##.widget:has(.simpl-adlabel)
 
 # https://github.com/NanoMeow/QuickReports/issues/2246
 spankwire.com###js-react-search-list div:has-text(/^Advertisement$/):upward(1)
-spankwire.com###js-react-video-player div:has-text(/^Advertisement$/):upward(2)
 spankwire.com##.adsbox
 
 # https://github.com/NanoAdblocker/NanoFilters/issues/489

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -299,8 +299,6 @@ marketscreener.com##.myFooter
 marketscreener.com##[id^="zpp"]
 
 # https://github.com/NanoMeow/QuickReports/issues/4266
-||engine.fxempire.com^
-||cdn.fxempire.com^
 fxempire.com##button:has-text(/Sponsored|Advertising Disclosure/):has(.fa-info-circle):upward([class*="fx-grid"])
 fxempire.com##span[id^="zone"]:empty:upward([class*="-sc-"][class*="__"]>div)
 fxempire.com##[class*="TopButtonAd"]

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -294,6 +294,10 @@ lmtonline.com###menuBar, #subHead:style(transform: none; -webkit-transform: none
 lmtonline.com###menuBar:style(margin-top: 50px !important;)
 lmtonline.com##.ctpl-fullbanner
 
+# https://github.com/NanoMeow/QuickReports/issues/3895
+marketscreener.com##.myFooter
+marketscreener.com##[id^="zpp"]
+
 # End Multilingual
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -2161,6 +2165,24 @@ tutorialspark.com###toprect
 
 # https://github.com/NanoMeow/QuickReports/issues/4439
 bestbuy.ca##[class^="advertisementListContainer"]:upward(3)
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/134
+joshuawright.net##.adsbygoogle:upward(1)
+
+# https://github.com/NanoMeow/QuickReports/issues/4080
+tellymix.co.uk##.adb_top
+tellymix.co.uk##.a-text
+
+# https://github.com/NanoMeow/QuickReports/issues/4066
+streamingmedia.com##.container1
+
+# https://github.com/NanoMeow/QuickReports/issues/4026
+abovetopsecret.com###third300
+abovetopsecret.com##.threadpost > [style^="width: 630px;"]
+
+# https://github.com/NanoMeow/QuickReports/issues/3915
+adage.com##.ad-entity-container
+adage.com###piano-inline_nsl
 
 # End English
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -301,10 +301,10 @@ marketscreener.com##[id^="zpp"]
 # https://github.com/NanoMeow/QuickReports/issues/4266
 ||engine.fxempire.com^
 ||cdn.fxempire.com^
-fxempire.com##button:has-text(Sponsored):has(.fa-info-circle):upward(div[class=""])
-fxempire.com##[class*="ColSystem"]>[class*="-sc-"]:has-text(/^Advertisement|Sponsored by$/)
-fxempire.com##[class^="fx-grid__Content"]:has-text(/Advertisement/)
+fxempire.com##button:has-text(/Sponsored|Advertising Disclosure/):has(.fa-info-circle):upward([class*="fx-grid"])
+fxempire.com##span[id^="zone"]:empty:upward([class*="-sc-"][class*="__"]>div)
 fxempire.com##[class*="TopButtonAd"]
+fxempire.com##li[class^="Tab-"] div[class*=" fx-grid__ColSystem-"]:has-text(Top Brokers)
 
 # End Multilingual
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -301,7 +301,8 @@ marketscreener.com##[id^="zpp"]
 # https://github.com/NanoMeow/QuickReports/issues/4266
 ||engine.fxempire.com^
 ||cdn.fxempire.com^
-fxempire.com##[class*="ColSystem"]>[class*="-sc-"]:has-text(/Sponsored|Advertisement/)
+fxempire.com##button:has-text(Sponsored):has(.fa-info-circle):upward(div[class=""])
+fxempire.com##[class*="ColSystem"]>[class*="-sc-"]:has-text(/^Advertisement|Sponsored by$/)
 fxempire.com##[class^="fx-grid__Content"]:has-text(/Advertisement/)
 fxempire.com##[class*="TopButtonAd"]
 

--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -306,6 +306,9 @@ fxempire.com##span[id^="zone"]:empty:upward([class*="-sc-"][class*="__"]>div)
 fxempire.com##[class*="TopButtonAd"]
 fxempire.com##li[class^="Tab-"] div[class*=" fx-grid__ColSystem-"]:has-text(Top Brokers)
 
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/134
+glosbe.com###topContainer
+
 # End Multilingual
 
 # -------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
* Fix https://github.com/NanoMeow/QuickReports/issues/3895
* Fix https://github.com/NanoMeow/QuickReports/issues/4080
* Fix https://github.com/NanoMeow/QuickReports/issues/4066
* Fix https://github.com/NanoMeow/QuickReports/issues/4026
* Fix https://github.com/NanoMeow/QuickReports/issues/3915
* Fix https://github.com/NanoMeow/QuickReports/issues/4266

Example pages:
```
! International
! Fix(?) https://github.com/NanoMeow/QuickReports/issues/3895
! https://www.marketscreener.com/
marketscreener.com##.myFooter
marketscreener.com##[id^="zpp"]
! Fix https://github.com/NanoMeow/QuickReports/issues/4266#issuecomment-670030414
! https://www.fxempire.com/news/article/china-blue-chip-index-hits-5-year-high-australian-shares-tumble-as-borders-close-659419
||engine.fxempire.com^
||cdn.fxempire.com^
fxempire.com##button:has-text(/Sponsored|Advertising Disclosure/):has(.fa-info-circle):upward([class*="fx-grid"])
fxempire.com##span[id^="zone"]:empty:upward([class*="-sc-"][class*="__"]>div)
fxempire.com##[class*="TopButtonAd"]
fxempire.com##li[class^="Tab-"] div[class*=" fx-grid__ColSystem-"]:has-text(Top Brokers)
! https://en.glosbe.com/nb/it/svada
glosbe.com###topContainer

! English
! http://www.joshuawright.net/slack-wyrm-642.html
joshuawright.net##.adsbygoogle:upward(1)
! Fix https://github.com/NanoMeow/QuickReports/issues/4080
! https://tellymix.co.uk/tv/444985-ant-and-dec-apologise-for-old-episodes-of-saturday-night-takeaway-featuring-blackface.html
tellymix.co.uk##.adb_top
tellymix.co.uk##.a-text
! Fix https://github.com/NanoMeow/QuickReports/issues/4066
! https://www.streamingmedia.com/Articles/ReadArticle.aspx?ArticleID=135703
streamingmedia.com##.container1
! Fix https://github.com/NanoMeow/QuickReports/issues/4026
! http://test.abovetopsecret.com/forum/thread1212355/pg1
abovetopsecret.com###third300
abovetopsecret.com##.threadpost > [style^="width: 630px;"]
! Fix https://github.com/NanoMeow/QuickReports/issues/3915
! https://adage.com/article/agency-news/tiktok-hires-rpa-and-initiative-ramp-us-marketing-efforts/2181191
adage.com##.ad-entity-container
adage.com###piano-inline_nsl
```

I also removed `spankwire.com###js-react-video-player div:has-text(/^Advertisement$/):upward(2)`, which seemed to me to hide the actual video on `https://www.spankwire.com/Hooded-latex-lesbian-lovers/video121301/`.