### PR TITLE
engadget.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -9,6 +9,9 @@
 
 # Multilingual
 
+# https://github.com/easylist/easylist/commit/96798d49e0909c09f7bf7d63ba593bd012973893
+engadget.com##ul[data-component=LatestStream] > li:has([data-component=GeminiAdItem])
+
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/3#issuecomment-450736303
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/5#issuecomment-452149638
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/21#issuecomment-487796545


### PR DESCRIPTION
URL: `https://www.engadget.com/`
Issue: a recent update in EL (https://github.com/easylist/easylist/commit/96798d49e0909c09f7bf7d63ba593bd012973893) leaves placeholder:

![engadget](https://user-images.githubusercontent.com/58900598/91031697-ea80f400-e63b-11ea-8ed7-5837dc1ecc0d.png)

Env: Firefox 79.0 + uBO 1.29.2 default lists, checked this is not covered by other rules in PHB.