### PR TITLE
itprotoday.com, whocallsme.com, fwi.co.uk, dnslytics.com

### DIFF
--- a/dist/placeholder-buster.txt
+++ b/dist/placeholder-buster.txt
@@ -827,7 +827,11 @@ bleepingcomputer.com##.cz-related-article-wrapp:has(:scope > .adsbygoogle)
 thehardtimes.net##.code-block:has(script:has-text(googletag))
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/26#issuecomment-495962647
+# https://github.com/NanoMeow/QuickReports/issues/4585
+!#if !env_mobile
 itprotoday.com##.banner-top-wrapper
+!#endif
+itprotoday.com##.banner-aside-wrapper + hr
 
 # https://github.com/NanoAdblockerLab/NanoContrib/pull/26#issuecomment-495962653
 howtogeek.com##.article-bottom
@@ -2244,6 +2248,15 @@ rightwingtribune.com##.z-ad-lockerdome-inline
 
 # https://github.com/NanoMeow/QuickReports/issues/4593
 thesaurus.com##aside[id*="_serp_"][id*="tf_"][class]
+
+# https://github.com/NanoMeow/QuickReports/issues/4548
+whocallsme.com##div[id^="cnt_"]
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/137
+fwi.co.uk##.page-split
+
+# https://github.com/NanoAdblockerLab/NanoContrib/pull/137
+dnslytics.com##.adboxcontentbrowse
 
 # End English
 


### PR DESCRIPTION
* Fix https://github.com/NanoMeow/QuickReports/issues/4585
* Fix https://github.com/NanoMeow/QuickReports/issues/4548
* Made one entry desktop-specific, because it would cause the top bar to overflow into the main body if the window happened to be very thin: 
![image](https://user-images.githubusercontent.com/22780683/91642523-45479080-ea2c-11ea-904d-b3323e1f8b8f.png)

Example entries for non-NanoMeow:
```
! https://www.fwi.co.uk/business/markets-and-trends/crop-prices/high-global-grain-crops-and-stocks-will-weigh-on-market
fwi.co.uk##.page-split

! https://dnslytics.com/ip/74.207.245.146
dnslytics.com##.adboxcontentbrowse
```